### PR TITLE
Add a listenToUnion utility

### DIFF
--- a/packages/jupyter-datawidgets/src/index.ts
+++ b/packages/jupyter-datawidgets/src/index.ts
@@ -5,7 +5,8 @@ export {
 } from './ndarray';
 
 export {
-  JSONToUnion, JSONToUnionArray, unionToJSON, data_union_serialization, data_union_array_serialization, getArrayFromUnion
+  JSONToUnion, JSONToUnionArray, unionToJSON, data_union_serialization,
+  data_union_array_serialization, getArrayFromUnion, listenToUnion
 } from './union';
 
 export {

--- a/packages/jupyter-datawidgets/src/union.ts
+++ b/packages/jupyter-datawidgets/src/union.ts
@@ -13,7 +13,12 @@ import * as _ from 'underscore';
 
 import ndarray = require('ndarray');
 
+export type DataUnion = NDArrayModel | ndarray.NDArray
 
+
+/**
+ * Deserializes union JSON to an ndarray or a NDArrayModel, as appropriate.
+ */
 export
 function JSONToUnion(obj: IReceivedSerializedArray | string | null, manager?: ManagerBase<any>): Promise<ndarray.NDArray | NDArrayModel | null> {
   if (typeof obj === 'string') {
@@ -25,7 +30,7 @@ function JSONToUnion(obj: IReceivedSerializedArray | string | null, manager?: Ma
 }
 
 /**
- * Serializes the union to an ndarray, regardless of whether it is a widget reference or direct data.
+ * Deserializes union JSON to an ndarray, regardless of whether it is a widget reference or direct data.
  */
 export
 function JSONToUnionArray(obj: IReceivedSerializedArray | string | null, manager?: ManagerBase<any>): Promise<ndarray.NDArray | null> {
@@ -39,21 +44,87 @@ function JSONToUnionArray(obj: IReceivedSerializedArray | string | null, manager
   }
 }
 
+/**
+ * Serializes a union to JSON.
+ */
 export
-function unionToJSON(obj: ndarray.NDArray | WidgetModel | null, widget?: WidgetModel): ISendSerializedArray | string | null {
-  if (obj instanceof WidgetModel) {
+function unionToJSON(obj: DataUnion | null, widget?: WidgetModel): ISendSerializedArray | string | null {
+  if (obj instanceof NDArrayModel) {
     return obj.toJSON(undefined);
   } else {
     return arrayToJSON(obj, widget);
   }
 }
 
+/**
+ * Gets the array of a union.
+ */
 export
-function getArrayFromUnion(union: NDArrayModel | ndarray.NDArray): ndarray.NDArray {
+function getArrayFromUnion(union: DataUnion): ndarray.NDArray {
   if (union instanceof NDArrayModel) {
     return union.get('array') as ndarray.NDArray;
   }
   return union;
+}
+
+/**
+ * Sets up backbone events for listening to union changes.
+ *
+ * The callback will be called when:
+ *  - The model is a widget, and its data changes
+ *
+ * To also want to cover these cases:
+ *  - The union changes from a widget to an array or vice-versa
+ *  - The union is an array and its content changes
+ * specify `allChanges` as truthy.
+ *
+ * To stop listening, call the return value.
+ */
+export
+function listenToUnion(model: Backbone.Model,
+                       unionName: string,
+                       callback: (model: Backbone.Model, options: any) => any,
+                       allChanges?: boolean
+                      ): () => void {
+
+  function listenToWidgetChanges(union: NDArrayModel) {
+    if (union instanceof NDArrayModel) {
+      // listen to changes in current model
+      model.listenTo(union, 'change', callback);
+      model.listenTo(union, 'childchange', callback);
+    }
+  }
+
+  function onUnionChange(unionModel: Backbone.Model, value: any, subOptions: any) {
+    var prev = model.previous(unionName) || [];
+    var curr = value || [];
+
+    if (prev instanceof NDArrayModel) {
+      model.stopListening(prev);
+    } else if (allChanges && !(curr instanceof NDArrayModel)) {
+      // The union was an array, and has changed to a new array
+      callback(unionModel, subOptions);
+    }
+    if (allChanges && (prev instanceof NDArrayModel) !== (curr instanceof NDArrayModel)) {
+      // Union type has changed, call out
+      callback(unionModel, subOptions);
+    }
+    listenToWidgetChanges(curr);
+  }
+
+  listenToWidgetChanges(model.get(unionName));
+
+  // make sure to (un)hook listeners when property changes
+  model.on('change:' + unionName, onUnionChange);
+
+  function stopListening() {
+    let curr = model.get(unionName);
+    if (curr instanceof NDArrayModel) {
+      model.stopListening(curr);
+    }
+    model.off('change:' + unionName, onUnionChange);
+  }
+  return stopListening;
 }
 
 export

--- a/packages/jupyter-datawidgets/src/union.ts
+++ b/packages/jupyter-datawidgets/src/union.ts
@@ -73,10 +73,9 @@ function getArrayFromUnion(union: DataUnion): ndarray.NDArray {
  * The callback will be called when:
  *  - The model is a widget, and its data changes
  *
- * To also want to cover these cases:
+ * Specify `allChanges` as truthy to also cover these cases:
  *  - The union changes from a widget to an array or vice-versa
  *  - The union is an array and its content changes
- * specify `allChanges` as truthy.
  *
  * To stop listening, call the return value.
  */


### PR DESCRIPTION
Adds a JS-side utility for the following case:

You have a widget model with a data union, and want a callback to be called whenever this changes. This utility abstracts away the logic for connecting/disconnecting to the correct events at the right times.

Note the last parameter `allChanges`. If false, the callback is only called for array changes to a child widget. This is to avoid duplicate calls when you also listen to `model.on('change', callback)`.