### PR TITLE
Ensure union notifies when widget array changes

### DIFF
--- a/ipydatawidgets/ndarray/__init__.py
+++ b/ipydatawidgets/ndarray/__init__.py
@@ -6,5 +6,5 @@
 
 from .serializers import array_serialization, data_union_serialization
 from .traits import NDArray, shape_constraints
-from .union import DataUnion
+from .union import DataUnion, get_union_array
 from .widgets import NDArrayWidget, ConstrainedNDArrayWidget

--- a/ipydatawidgets/ndarray/union.py
+++ b/ipydatawidgets/ndarray/union.py
@@ -68,3 +68,9 @@ class DataUnion(Union):
             else:
                 self.shape_constraint(self, value)
         return value
+
+
+def get_union_array(union):
+    if isinstance(union, NDArrayWidget):
+        return union.array
+    return union

--- a/ipydatawidgets/ndarray/union.py
+++ b/ipydatawidgets/ndarray/union.py
@@ -34,6 +34,7 @@ class DataUnion(Union):
         self.tag(**data_union_serialization)
 
         self._registered_validators = {}
+        self._registered_observer = {}
 
     def instance_init(self, inst):
         inst.observe(self._on_instance_value_change, self.name)
@@ -41,14 +42,26 @@ class DataUnion(Union):
     def _on_instance_value_change(self, change):
         inst = change['owner']
         if isinstance(change['old'], NDArrayWidget):
-            f = self._registered_validators.get(inst, None)
+            f = self._registered_validators.pop(inst, None)
             if f is not None:
                 change['old']._instance_validators.remove(f)
+
+            f = self._registered_observer.pop(inst, None)
+            if f is not None:
+                change['old'].unobserve(f)
         if isinstance(change['new'], NDArrayWidget):
             # We can validate directly, since our validator accepts arrays also:
             f = partial(self._valdiate_child, inst)
             self._registered_validators[inst] = f
             change['new']._instance_validators.add(f)
+
+            f = partial(self._on_widget_array_change, inst)
+            self._registered_observer[inst] = f
+            change['new'].observe(f, 'array')
+
+    def _on_widget_array_change(self, union, change):
+        inst = change['owner']
+        union._notify_trait(self.name, inst, inst)
 
     def _valdiate_child(self, obj, value):
         try:

--- a/ipydatawidgets/tests/test_widgets.py
+++ b/ipydatawidgets/tests/test_widgets.py
@@ -40,11 +40,11 @@ def test_constrained_datawidget():
     np.testing.assert_equal(w.array, np.zeros((4, 4, 3), dtype=np.uint8))
 
 
-def test_manual_notification(mock_comm):
+def test_notification(mock_comm):
     data = np.zeros((2, 4))
     w = NDArrayWidget(data)
     w.comm = mock_comm
-    w.notify_changed()
+    w.array = np.ones((2, 4, 2))
 
     assert len(mock_comm.log_send) == 1
 


### PR DESCRIPTION
This change ensures that any observers of a DataUnion trait gets notified when the union is set to a widget, and the widget's data changes. The old and new values in the change notification are currently the same.