### PR TITLE
Import __version__ properly in __init__.py.

### DIFF
--- a/ipydatawidgets/__init__.py
+++ b/ipydatawidgets/__init__.py
@@ -8,6 +8,6 @@ from .ndarray import *
 from .trait_types import Validators
 from .widgets import DataWidget
 from .scaled import ScaledArrayWidget
-from ._version import *
+from ._version import __version__, version_info
 
 from .nbextension import _jupyter_nbextension_paths


### PR DESCRIPTION
`import *` doesn't include symbols starting with underscore.