### PR TITLE
Add more serializer types

### DIFF
--- a/packages/serializers/src/common.ts
+++ b/packages/serializers/src/common.ts
@@ -47,7 +47,7 @@ function isDataSource(data: any): data is IDataSource {
  * Gets the array of any array source.
  */
 export
-function getArray(data: DataUnion | IDataSource | null): ndarray | null {
+function getArray(data: DataUnion | null): ndarray | null {
   if (isDataSource(data)) {
     return data.getNDArray();
   }

--- a/packages/serializers/src/ndarray.ts
+++ b/packages/serializers/src/ndarray.ts
@@ -87,6 +87,14 @@ function ensureSerializableDtype(dtype: ndarray.DataType): keyof IArrayLookup {
 }
 
 
+/**
+ * Deserialize from JSON to an ndarray object.
+ *
+ * @param obj The deserialized JSON to convert
+ * @param manager The owning widget manager
+ *
+ * @returns A new ndarray object.
+ */
 export
 function JSONToArray(obj: IReceivedSerializedArray | null, manager?: ManagerBase<any>): ndarray | null {
   if (obj === null) {
@@ -97,6 +105,15 @@ function JSONToArray(obj: IReceivedSerializedArray | null, manager?: ManagerBase
   return ndarray(new typesToArray[obj.dtype](obj.buffer.buffer), obj.shape);
 }
 
+
+/**
+ * Serialize to JSON from an ndarray object.
+ *
+ * @param obj The ndarray object to convert
+ * @param manager The owning widget model
+ *
+ * @returns The JSON object representing the ndarray.
+ */
 export
 function arrayToJSON(obj: ndarray | null, widget?: WidgetModel): ISendSerializedArray | null {
   if (obj === null) {
@@ -107,6 +124,9 @@ function arrayToJSON(obj: ndarray | null, widget?: WidgetModel): ISendSerialized
   return { shape: obj.shape, dtype, buffer: obj.data as TypedArray };
 }
 
+/**
+ * Serializers for to/from ndarrays
+ */
 export
 const array_serialization = { deserialize: JSONToArray, serialize: arrayToJSON };
 

--- a/packages/serializers/src/ndarray.ts
+++ b/packages/serializers/src/ndarray.ts
@@ -185,3 +185,125 @@ const compressed_array_serialization = {
   deserialize: compressedJSONToArray,
   serialize: arrayToCompressedJSON
 };
+
+
+export
+function typedArrayToType(array: TypedArray): keyof IArrayLookup {
+  if (array instanceof Int8Array) {
+    return 'int8';
+  } else if (array instanceof Int16Array) {
+    return 'int16';
+  } else if (array instanceof Int32Array) {
+    return 'int32';
+  } else if (array instanceof Uint8Array) {
+    return 'uint8';
+  } else if (array instanceof Uint8ClampedArray) {
+    return 'uint8';
+  } else if (array instanceof Uint16Array) {
+    return 'uint16';
+  } else if (array instanceof Uint32Array) {
+    return 'uint32';
+  } else if (array instanceof Float32Array) {
+    return 'float32';
+  } else if (array instanceof Float64Array) {
+    return 'float64';
+  } else {
+    throw new Error(`Unknown TypedArray type: ${array}`);
+  }
+};
+
+
+
+/**
+ * Deserialize from JSON to a typed array. Discards shape information.
+ *
+ * @param obj The deserialized JSON to convert
+ * @param manager The owning widget manager
+ *
+ * @returns A new typed array.
+ */
+export
+function JSONToTypedArray(obj: IReceivedSerializedArray | null, manager?: ManagerBase<any>): TypedArray | null {
+  if (obj === null) {
+    return null;
+  }
+  // obj is {shape: list, dtype: string, array: DataView}
+  return new typesToArray[obj.dtype](obj.buffer.buffer);
+}
+
+
+/**
+ * Serialize to JSON from a typed array.
+ *
+ * @param obj The typed array to convert
+ * @param manager The owning widget model
+ *
+ * @returns The JSON object representing the typed array.
+ */
+export
+function typedArrayToJSON(obj: TypedArray | null, widget?: WidgetModel): ISendSerializedArray | null {
+  if (obj === null) {
+    return null;
+  }
+  // serialize to {shape: list, dtype: string, array: buffer}
+  return { shape: [obj.length], dtype: typedArrayToType(obj), buffer: obj };
+}
+
+
+/**
+ * Serializers for to/from 1D typed array
+ */
+export
+const typedarray_serialization = { deserialize: JSONToTypedArray, serialize: typedArrayToJSON };
+
+
+
+export
+interface ISimpleObject {
+  array: TypedArray;
+  shape: number[];
+}
+
+
+/**
+ * Deserialize from JSON to a simple object with shape and typed array.
+ *
+ * @param obj The deserialized JSON to convert
+ * @param manager The owning widget manager
+ *
+ * @returns A new object containg the data.
+ */
+export
+function JSONToSimple(obj: IReceivedSerializedArray | null, manager?: ManagerBase<any>): ISimpleObject | null {
+  if (obj === null) {
+    return null;
+  }
+  // obj is {shape: list, dtype: string, array: DataView}
+  return { array: new typesToArray[obj.dtype](obj.buffer.buffer), shape: obj.shape};
+}
+
+
+/**
+ * Serialize to JSON from a simple object.
+ *
+ * @param obj The simple object to convert
+ * @param manager The owning widget model
+ *
+ * @returns The JSON object representing the simple object.
+ */
+export
+function simpleToJSON(obj: ISimpleObject | null, widget?: WidgetModel): ISendSerializedArray | null {
+  if (obj === null) {
+    return null;
+  }
+  // serialize to {shape: list, dtype: string, array: buffer}
+  return { shape: obj.shape, dtype: typedArrayToType(obj.array), buffer: obj.array };
+}
+
+
+/**
+ * Serializers for to/from 1D simple object containing array and metadata.
+ */
+export
+const simplearray_serialization = { deserialize: JSONToSimple, serialize: simpleToJSON };
+

--- a/packages/serializers/tests/src/ndarray.spec.ts
+++ b/packages/serializers/tests/src/ndarray.spec.ts
@@ -15,7 +15,9 @@ import {
   arrayToJSON, JSONToArray, IReceivedSerializedArray,
   IReceivedCompressedSerializedArray,
   ensureSerializableDtype, typesToArray,
-  arrayToCompressedJSON, compressedJSONToArray, ISendCompressedSerializedArray
+  arrayToCompressedJSON, compressedJSONToArray, ISendCompressedSerializedArray,
+  JSONToTypedArray, typedArrayToJSON, JSONToSimple,
+  simpleToJSON, typedArrayToType
 } from '../../src'
 
 import ndarray = require('ndarray');
@@ -25,7 +27,7 @@ import pako = require("pako");
 
 describe('ndarray', () => {
 
-  describe('serializers', () => {
+  describe('standard serializers', () => {
 
     it('should deserialize an array', () => {
 
@@ -199,6 +201,96 @@ describe('ndarray', () => {
     });
 
   });
+  describe('TypedArray serializers', () => {
+
+    it('should deserialize an array', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+      let view = new DataView(raw_data.buffer);
+      let jsonData = {
+        buffer: view,
+        shape: [2, 3],
+        dtype: 'float32',
+      } as IReceivedSerializedArray;
+
+      let array = JSONToTypedArray(jsonData)!;
+
+      expect(array).to.be.a(Float32Array);
+      expect((array as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(array.length).to.eql(6);
+
+    });
+
+    it('should deserialize null to null', () => {
+      let output = JSONToTypedArray(null);
+      expect(output).to.be(null);
+    });
+
+    it('should serialize an ndarray', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+
+      let jsonData = typedArrayToJSON(raw_data)!;
+
+      expect(jsonData.buffer).to.be.a(Float32Array);
+      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.shape).to.eql([6]);
+      expect(jsonData.dtype).to.be('float32');
+
+    });
+
+    it('should serialize null to null', () => {
+      let output = typedArrayToJSON(null);
+      expect(output).to.be(null);
+    });
+
+  });
+
+  describe('simple serializers', () => {
+
+    it('should deserialize an array', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+      let view = new DataView(raw_data.buffer);
+      let jsonData = {
+        buffer: view,
+        shape: [2, 3],
+        dtype: 'float32',
+      } as IReceivedSerializedArray;
+
+      let obj = JSONToSimple(jsonData)!;
+
+      expect(obj.array).to.be.a(Float32Array);
+      expect((obj.array as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(obj.shape).to.eql([2, 3]);
+
+    });
+
+    it('should deserialize null to null', () => {
+      let output = JSONToSimple(null);
+      expect(output).to.be(null);
+    });
+
+    it('should serialize an ndarray', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+      let obj = {array: raw_data, shape: [2, 3]}
+
+      let jsonData = simpleToJSON(obj)!;
+
+      expect(jsonData.buffer).to.be.a(Float32Array);
+      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.shape).to.eql([2, 3]);
+      expect(jsonData.dtype).to.be('float32');
+
+    });
+
+    it('should serialize null to null', () => {
+      let output = simpleToJSON(null);
+      expect(output).to.be(null);
+    });
+
+  });
 
   describe('ensureSerializableDtype', () => {
 
@@ -228,6 +320,51 @@ describe('ndarray', () => {
         }
         expect(ensureSerializableDtype(k as any)).to.be(k);
       }
+    });
+
+  });
+
+  describe('typedArrayToType', () => {
+
+    it('should handle int8', () => {
+      expect(typedArrayToType(new Int8Array(0))).to.be('int8');
+    });
+
+    it('should handle uint8', () => {
+      expect(typedArrayToType(new Uint8Array(0))).to.be('uint8');
+    });
+
+    it('should handle int16', () => {
+      expect(typedArrayToType(new Int16Array(0))).to.be('int16');
+    });
+
+    it('should handle uint16', () => {
+      expect(typedArrayToType(new Uint16Array(0))).to.be('uint16');
+    });
+
+    it('should handle int32', () => {
+      expect(typedArrayToType(new Int32Array(0))).to.be('int32');
+    });
+
+    it('should handle uint32', () => {
+      expect(typedArrayToType(new Uint32Array(0))).to.be('uint32');
+    });
+
+    it('should handle float32', () => {
+      expect(typedArrayToType(new Float32Array(0))).to.be('float32');
+    });
+
+    it('should handle float64', () => {
+      expect(typedArrayToType(new Float64Array(0))).to.be('float64');
+    });
+
+    it('should return uint8 for clamped array', () => {
+      expect(typedArrayToType(new Uint8ClampedArray(0))).to.be('uint8');
+    });
+
+    it('should raise an error for unknown types', () => {
+      expect(typedArrayToType)
+        .withArgs([]).to.throwException(/Unknown TypedArray type.*/);
     });
 
   });

--- a/packages/serializers/tests/src/union.spec.ts
+++ b/packages/serializers/tests/src/union.spec.ts
@@ -11,7 +11,8 @@ import {
 
 import {
   JSONToUnion, JSONToUnionArray, unionToJSON, IReceivedSerializedArray,
-  ISendSerializedArray, listenToUnion
+  ISendSerializedArray, listenToUnion, JSONToUnionTypedArray,
+  unionTypedArrayToJSON, JSONToSimpleUnion, simpleUnionToJSON
 } from '../../src';
 
 import {
@@ -19,7 +20,7 @@ import {
 } from './dummy-manager.spec';
 
 import {
-  createTestModel, TestModel
+  createTestModel, TestModel, NullTestModel
 } from './util.spec';
 
 
@@ -66,7 +67,7 @@ describe('Union Serializers', () => {
       // Model is now set up. Try to deserialize a reference to the widget:
       let jsonData = model.toJSON(undefined);
       return JSONToUnionArray(jsonData, widget_manager).then((array) => {
-        // Ensure that the ref deseriealizes to the inner ndarray:
+        // Ensure that the ref deserializes to the inner ndarray:
         expect(array!.data).to.be.a(Float32Array);
         expect((array!.data as Float32Array).buffer).to.be(model.raw_data.buffer);
         expect(array!.shape).to.eql([2, 3]);
@@ -157,6 +158,197 @@ describe('Union Serializers', () => {
       let model = createTestModel(TestModel);
 
       let jsonData = unionToJSON(model);
+      expect(jsonData).to.be(model.toJSON(undefined));
+    });
+
+  });
+
+  describe('JSONToUnionTypedArray', () => {
+
+    it('should deserialize an array', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+      let view = new DataView(raw_data.buffer);
+      let jsonData = {
+        buffer: view,
+        shape: [2, 3],
+        dtype: 'float32',
+      } as IReceivedSerializedArray;
+
+      let arrayPromise = JSONToUnionTypedArray(jsonData);
+
+      return arrayPromise.then((array) => {
+        expect(array).to.be.a(Float32Array);
+        expect((array as Float32Array).buffer).to.be(raw_data.buffer);
+        expect(array!.length).to.eql(6);
+
+      });
+    });
+
+    it('should deserialize null to null', () => {
+      return JSONToUnionTypedArray(null).then((output) => {
+        expect(output).to.be(null);
+      })
+    });
+
+    it('should deserialize a widget ref to an array', () => {
+
+      // First set up an NDArrayModel
+
+      let widget_manager = new DummyManager();
+
+      let model = createTestModel(TestModel, {}, widget_manager);
+      (widget_manager as any)._models[model.model_id] = Promise.resolve(model);
+
+      // Model is now set up. Try to deserialize a reference to the widget:
+      let jsonData = model.toJSON(undefined);
+      return JSONToUnionTypedArray(jsonData, widget_manager).then((array) => {
+        // Ensure that the ref deserializes to the inner typed array:
+        expect(array).to.be.a(Float32Array);
+        expect((array as Float32Array).buffer).to.be(model.raw_data.buffer);
+        expect(array!.length).to.eql(6);
+      });
+    });
+
+    it('should deserialize a widget ref with null array to null', () => {
+
+      // First set up an NDArrayModel
+
+      let widget_manager = new DummyManager();
+
+      let model = createTestModel(NullTestModel, {}, widget_manager);
+      (widget_manager as any)._models[model.model_id] = Promise.resolve(model);
+
+      // Model is now set up. Try to deserialize a reference to the widget:
+      let jsonData = model.toJSON(undefined);
+      return JSONToUnionTypedArray(jsonData, widget_manager).then((array) => {
+        // Ensure that the ref deserializes to null:
+        expect(array).to.be(null);
+      });
+    });
+
+  });
+
+  describe('unionTypedArrayToJSON', () => {
+
+    it('should serialize a TypedArray', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+
+      let jsonData = unionTypedArrayToJSON(raw_data) as ISendSerializedArray;
+
+      expect(jsonData.buffer).to.be.a(Float32Array);
+      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.shape).to.eql([6]);
+      expect(jsonData.dtype).to.be('float32');
+
+    });
+
+    it('should serialize null to null', () => {
+      let output = unionTypedArrayToJSON(null);
+      expect(output).to.be(null);
+    });
+
+    it('should serialize a widget', () => {
+      let model = createTestModel(TestModel);
+
+      let jsonData = unionTypedArrayToJSON(model);
+      expect(jsonData).to.be(model.toJSON(undefined));
+    });
+
+  });
+
+  describe('JSONToSimpleUnion', () => {
+
+    it('should deserialize an array', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+      let view = new DataView(raw_data.buffer);
+      let jsonData = {
+        buffer: view,
+        shape: [2, 3],
+        dtype: 'float32',
+      } as IReceivedSerializedArray;
+
+      let objPromise = JSONToSimpleUnion(jsonData);
+
+      return objPromise.then((obj) => {
+        expect(obj!.array).to.be.a(Float32Array);
+        expect((obj!.array as Float32Array).buffer).to.be(raw_data.buffer);
+        expect(obj!.shape).to.eql([2, 3]);
+
+      });
+    });
+
+    it('should deserialize null to null', () => {
+      return JSONToSimpleUnion(null).then((output) => {
+        expect(output).to.be(null);
+      })
+    });
+
+    it('should deserialize a widget ref to a simple object', () => {
+
+      // First set up an NDArrayModel
+
+      let widget_manager = new DummyManager();
+
+      let model = createTestModel(TestModel, {}, widget_manager);
+      (widget_manager as any)._models[model.model_id] = Promise.resolve(model);
+
+      // Model is now set up. Try to deserialize a reference to the widget:
+      let jsonData = model.toJSON(undefined);
+      return JSONToSimpleUnion(jsonData, widget_manager).then((obj) => {
+        // Ensure that the ref deserializes to the inner ndarray:
+        expect(obj!.array).to.be.a(Float32Array);
+        expect((obj!.array as Float32Array).buffer).to.be(model.raw_data.buffer);
+        expect(obj!.shape).to.eql([2, 3]);
+      });
+    });
+
+    it('should deserialize a widget ref with null array to null', () => {
+
+      // First set up an NDArrayModel
+
+      let widget_manager = new DummyManager();
+
+      let model = createTestModel(NullTestModel, {}, widget_manager);
+      (widget_manager as any)._models[model.model_id] = Promise.resolve(model);
+
+      // Model is now set up. Try to deserialize a reference to the widget:
+      let jsonData = model.toJSON(undefined);
+      return JSONToSimpleUnion(jsonData, widget_manager).then((array) => {
+        // Ensure that the ref deserializes to null:
+        expect(array).to.be(null);
+      });
+    });
+
+  });
+
+  describe('simpleUnionToJSON', () => {
+
+    it('should serialize a simple object', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+      let obj = {array: raw_data, shape: [2, 3]}
+
+      let jsonData = simpleUnionToJSON(obj) as ISendSerializedArray;
+
+      expect(jsonData.buffer).to.be.a(Float32Array);
+      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.shape).to.eql([2, 3]);
+      expect(jsonData.dtype).to.be('float32');
+
+    });
+
+    it('should serialize null to null', () => {
+      let output = simpleUnionToJSON(null);
+      expect(output).to.be(null);
+    });
+
+    it('should serialize a widget', () => {
+      let model = createTestModel(TestModel);
+
+      let jsonData = simpleUnionToJSON(model);
       expect(jsonData).to.be(model.toJSON(undefined));
     });
 

--- a/packages/serializers/tests/src/util.spec.ts
+++ b/packages/serializers/tests/src/util.spec.ts
@@ -23,6 +23,14 @@ interface ModelConstructor<T> {
 
 
 export
+class NullTestModel extends WidgetModel implements IDataSource {
+  getNDArray(key?: string): ndarray | null {
+    return null;
+  }
+}
+
+
+export
 class TestModel extends WidgetModel implements IDataSource {
   initialize(attributes: any, options: any) {
     super.initialize(attributes, options);
@@ -37,7 +45,7 @@ class TestModel extends WidgetModel implements IDataSource {
     }
   }
 
-  getNDArray(key?: string): ndarray {
+  getNDArray(key?: string): ndarray | null {
     return this.array;
   }
 


### PR DESCRIPTION
Add (de-)serializers on the JS side to enable direct consumption of array/union as:
- A `TypedArray` (shape information discarded).
- A simple JS object with attributes `array` (a `TypedArray`) and `shape`.

Note: The typed array serializer risks overwriting the original shape of the array, so care should be taken when using that.

cc @maartenbreddels , @artur-trzesiok