### PR TITLE
Add support for compression

### DIFF
--- a/ipydatawidgets/ndarray/serializers.py
+++ b/ipydatawidgets/ndarray/serializers.py
@@ -95,10 +95,15 @@ def array_to_compressed_json(value, widget):
     """Compressed array JSON serializer."""
     state = array_to_json(value, widget)
     compression = getattr(widget, 'compression_level', 0)
+    buffer = state.pop('buffer')
+    if six.PY2:
+        buffer = buffer.tobytes()
     state['compressed_buffer'] = zlib.compress(
-        state.pop('buffer'),
+        buffer,
         compression
     )
+    if six.PY2:
+        state['compressed_buffer'] = memoryview(state['compressed_buffer'])
     return state
 
 
@@ -106,7 +111,11 @@ def array_from_compressed_json(value, widget):
     """Compressed array JSON de-serializer."""
     comp = value.pop('compressed_buffer', None)
     if comp is not None:
+        if six.PY2:
+            comp = comp.tobytes()
         value['buffer'] = zlib.decompress(comp)
+        if six.PY2:
+            value['buffer'] = memoryview(value['buffer'])
     return array_from_json(value, widget)
 
 

--- a/packages/jupyter-datawidgets/src/ndarray.ts
+++ b/packages/jupyter-datawidgets/src/ndarray.ts
@@ -10,7 +10,7 @@ import {
 } from './base';
 
 import {
-  ISerializers, array_serialization
+  ISerializers, compressed_array_serialization
 } from 'jupyter-dataserializers';
 
 import ndarray = require('ndarray');
@@ -21,6 +21,7 @@ class NDArrayModel extends DataModel {
   defaults() {
     return {...super.defaults(), ...{
       array: ndarray([]),
+      compression_level: 0,
       _model_name: NDArrayModel.model_name,
     }} as any;
   }
@@ -31,7 +32,7 @@ class NDArrayModel extends DataModel {
 
   static serializers: ISerializers = {
       ...DataModel.serializers,
-      array: array_serialization,
+      array: compressed_array_serialization,
     };
 
   static model_name = 'NDArrayModel';

--- a/packages/jupyter-datawidgets/tests/src/tsconfig.json
+++ b/packages/jupyter-datawidgets/tests/src/tsconfig.json
@@ -2,12 +2,12 @@
   "compilerOptions": {
     "declaration": true,
     "noImplicitAny": true,
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
+    "lib": ["dom", "es6"],
     "noEmitOnError": true,
     "strictNullChecks": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "ES5",
+    "target": "ES6",
     "outDir": "../build",
     "skipLibCheck": true,
     "sourceMap": true

--- a/packages/serializers/package.json
+++ b/packages/serializers/package.json
@@ -25,6 +25,7 @@
     "@types/mocha": "^2.2.48",
     "@types/ndarray": "^1.0.5",
     "@types/node": "^9.4.6",
+    "@types/pako": "^1.0.0",
     "expect.js": "^0.3.1",
     "karma": "^2.0.0",
     "karma-chrome-launcher": "^2.2.0",
@@ -38,6 +39,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.8",
-    "ndarray": "^1.0.18"
+    "ndarray": "^1.0.18",
+    "pako": "^1.0.6"
   }
 }

--- a/packages/serializers/tests/src/ndarray.spec.ts
+++ b/packages/serializers/tests/src/ndarray.spec.ts
@@ -4,15 +4,23 @@
 import expect = require('expect.js');
 
 import {
-  uuid
-} from '@jupyter-widgets/base';
+  DummyManager
+} from './dummy-manager.spec';
+
+import {
+  createTestModel, TestModel
+} from './util.spec';
 
 import {
   arrayToJSON, JSONToArray, IReceivedSerializedArray,
-  ensureSerializableDtype, typesToArray
+  IReceivedCompressedSerializedArray,
+  ensureSerializableDtype, typesToArray,
+  arrayToCompressedJSON, compressedJSONToArray, ISendCompressedSerializedArray
 } from '../../src'
 
 import ndarray = require('ndarray');
+
+import pako = require("pako");
 
 
 describe('ndarray', () => {
@@ -60,6 +68,134 @@ describe('ndarray', () => {
     it('should serialize null to null', () => {
       let output = arrayToJSON(null);
       expect(output).to.be(null);
+    });
+
+  });
+
+
+  describe('compressed serializers', () => {
+
+    it('should deserialize a non-compressed array', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+      let view = new DataView(raw_data.buffer);
+      let jsonData = {
+        buffer: view,
+        shape: [2, 3],
+        dtype: 'float32',
+      } as IReceivedSerializedArray;
+
+      let array = compressedJSONToArray(jsonData)!;
+
+      expect(array.data).to.be.a(Float32Array);
+      expect((array.data as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(array.shape).to.eql([2, 3]);
+      expect(array.dtype).to.be('float32');
+
+    });
+
+    it('should deserialize a compressed array', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+      const level = 6;
+      let view = new DataView(pako.deflate(raw_data.buffer as any, { level }).buffer);
+      let jsonData = {
+        compressed_buffer: view,
+        shape: [2, 3],
+        dtype: 'float32',
+      } as IReceivedCompressedSerializedArray;
+
+      let array = compressedJSONToArray(jsonData)!;
+
+      expect(array.data).to.be.a(Float32Array);
+      // Not .to.be here, as run through compression loop:
+      expect((array.data as Float32Array).buffer).to.not.be(raw_data.buffer);
+      expect((array.data as Float32Array).buffer).to.eql(raw_data.buffer);
+      expect(array.shape).to.eql([2, 3]);
+      expect(array.dtype).to.be('float32');
+
+    });
+
+    it('should deserialize null to null', () => {
+      let output = compressedJSONToArray(null);
+      expect(output).to.be(null);
+    });
+
+    it('should serialize an uncompressed ndarray', () => {
+
+      // First set up a test NDArrayModel
+      let widget_manager = new DummyManager();
+
+      let model = createTestModel(TestModel, {}, widget_manager);
+      (widget_manager as any)._models[model.model_id] = Promise.resolve(model);
+      model.set('compression_level', 0);
+
+      let jsonData = arrayToCompressedJSON(model.array, model)!;
+
+      expect(jsonData.buffer).to.be.a(Float32Array);
+      expect((jsonData.buffer as Float32Array).buffer).to.be(model.raw_data.buffer);
+      expect(jsonData.shape).to.eql([2, 3]);
+      expect(jsonData.dtype).to.be('float32');
+
+    });
+
+    it('should serialize a compressed ndarray', () => {
+
+      // First set up a test NDArrayModel
+      let widget_manager = new DummyManager();
+
+      let model = createTestModel(TestModel, {}, widget_manager);
+      (widget_manager as any)._models[model.model_id] = Promise.resolve(model);
+      model.set('compression_level', 6);
+
+      let jsonData = arrayToCompressedJSON(model.array, model) as ISendCompressedSerializedArray;
+
+      expect(jsonData.buffer).to.be(undefined);
+      expect(jsonData.compressed_buffer).to.be.a(Uint8Array);
+      // Not .to.be here, as run through compression loop:
+      expect(jsonData.compressed_buffer!.buffer).to.not.be(model.raw_data.buffer);
+      expect(jsonData.compressed_buffer).to.not.eql(
+        new Uint8Array(model.raw_data.buffer));
+      expect(jsonData.shape).to.eql([2, 3]);
+      expect(jsonData.dtype).to.be('float32');
+
+    });
+
+    it('should serialize null to null', () => {
+      let output = arrayToCompressedJSON(null);
+      expect(output).to.be(null);
+    });
+
+    it('should not compress when model not given', () => {
+
+      let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+      let array = ndarray(raw_data, [2, 3]);
+
+      let jsonData = arrayToCompressedJSON(array)!;
+
+      expect(jsonData.buffer).to.be.a(Float32Array);
+      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.shape).to.eql([2, 3]);
+      expect(jsonData.dtype).to.be('float32');
+
+    });
+
+    it('should not compress a model without compression_level', () => {
+
+      // First set up a test NDArrayModel
+      let widget_manager = new DummyManager();
+
+      let model = createTestModel(TestModel, {}, widget_manager);
+      (widget_manager as any)._models[model.model_id] = Promise.resolve(model);
+      model.unset('compression_level');
+
+      let jsonData = arrayToCompressedJSON(model.array, model)!;
+
+      expect(jsonData.buffer).to.be.a(Float32Array);
+      expect((jsonData.buffer as Float32Array).buffer).to.be(model.raw_data.buffer);
+      expect(jsonData.shape).to.eql([2, 3]);
+      expect(jsonData.dtype).to.be('float32');
+
     });
 
   });

--- a/packages/serializers/tests/src/tsconfig.json
+++ b/packages/serializers/tests/src/tsconfig.json
@@ -2,12 +2,12 @@
   "compilerOptions": {
     "declaration": true,
     "noImplicitAny": true,
-    "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
+    "lib": ["dom", "es6"],
     "noEmitOnError": true,
     "strictNullChecks": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "ES5",
+    "target": "ES6",
     "outDir": "../build",
     "skipLibCheck": true,
     "sourceMap": true

--- a/packages/serializers/tests/src/union.spec.ts
+++ b/packages/serializers/tests/src/union.spec.ts
@@ -11,7 +11,7 @@ import {
 
 import {
   JSONToUnion, JSONToUnionArray, unionToJSON, IReceivedSerializedArray,
-  ISendSerializedArray, listenToUnion, IDataSource
+  ISendSerializedArray, listenToUnion
 } from '../../src';
 
 import {
@@ -19,24 +19,8 @@ import {
 } from './dummy-manager.spec';
 
 import {
-  createTestModel
+  createTestModel, TestModel
 } from './util.spec';
-
-
-class TestModel extends WidgetModel implements IDataSource {
-  initialize(attributes: any, options: any) {
-    super.initialize(attributes, options);
-    this.raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
-    this.array = ndarray(this.raw_data, [2, 3]);
-  }
-
-  getNDArray(key?: string): ndarray {
-    return this.array;
-  }
-
-  raw_data: Float32Array;
-  array: ndarray;
-}
 
 
 describe('Union Serializers', () => {

--- a/packages/serializers/tests/src/util.spec.ts
+++ b/packages/serializers/tests/src/util.spec.ts
@@ -9,10 +9,42 @@ import {
   DummyManager
 } from './dummy-manager.spec';
 
+import {
+  IDataSource
+} from '../../src';
+
+import ndarray = require('ndarray');
+
+
 export
 interface ModelConstructor<T> {
     new (attributes?: any, options?: any): T;
 }
+
+
+export
+class TestModel extends WidgetModel implements IDataSource {
+  initialize(attributes: any, options: any) {
+    super.initialize(attributes, options);
+    this.raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+    this.array = ndarray(this.raw_data, [2, 3]);
+  }
+
+  defaults() {
+    return {
+      ...super.defaults(),
+      compression_level: 0,
+    }
+  }
+
+  getNDArray(key?: string): ndarray {
+    return this.array;
+  }
+
+  raw_data: Float32Array;
+  array: ndarray;
+}
+
 
 export
 function createTestModel<T extends WidgetModel>(


### PR DESCRIPTION
This allows for turning on zlib compression on individual data widgets. Ideally, compression should be turned on at the notebook application level, as that is more efficient. However, this allows for user control in cases where they do not have the privileges to modify the notebook application parameters.

Loosly based on code from k3d, CC @artur-trzesiok.