### PR TITLE
Rename 'buffer' to 'data' in serialized state

### DIFF
--- a/ipydatawidgets/ndarray/serializers.py
+++ b/ipydatawidgets/ndarray/serializers.py
@@ -68,8 +68,8 @@ def array_to_json(value, widget):
     return {
         'shape': value.shape,
         'dtype': str(value.dtype),
-        #'buffer': memoryview(value) # maybe should do array.tobytes(order='C') to copy
-        'buffer': memoryview(value)
+        #'data': memoryview(value) # maybe should do array.tobytes(order='C') to copy
+        'data': memoryview(value)
     }
 
 
@@ -81,10 +81,10 @@ def array_from_json(value, widget):
     if six.PY2:
         # Numpy does not support frombuffer with memoryview
         # on Python 2:
-        buffer = value['buffer'].tobytes()
+        buffer = value['data'].tobytes()
         n = np.frombuffer(buffer, dtype=value['dtype'])
     else:
-        n = np.frombuffer(value['buffer'], dtype=value['dtype'])
+        n = np.frombuffer(value['data'], dtype=value['dtype'])
     n.shape = value['shape']
     return n
 
@@ -99,27 +99,27 @@ def array_to_compressed_json(value, widget):
     compression = getattr(widget, 'compression_level', 0)
     if compression == 0:
         return state
-    buffer = state.pop('buffer')
+    buffer = state.pop('data')
     if six.PY2:
         buffer = buffer.tobytes()
-    state['compressed_buffer'] = zlib.compress(
+    state['compressed_data'] = zlib.compress(
         buffer,
         compression
     )
     if six.PY2:
-        state['compressed_buffer'] = memoryview(state['compressed_buffer'])
+        state['compressed_data'] = memoryview(state['compressed_data'])
     return state
 
 
 def array_from_compressed_json(value, widget):
     """Compressed array JSON de-serializer."""
-    comp = value.pop('compressed_buffer', None) if value is not None else None
+    comp = value.pop('compressed_data', None) if value is not None else None
     if comp is not None:
         if six.PY2:
             comp = comp.tobytes()
-        value['buffer'] = zlib.decompress(comp)
+        value['data'] = zlib.decompress(comp)
         if six.PY2:
-            value['buffer'] = memoryview(value['buffer'])
+            value['data'] = memoryview(value['data'])
     return array_from_json(value, widget)
 
 

--- a/ipydatawidgets/tests/test_ndarray_serializers.py
+++ b/ipydatawidgets/tests/test_ndarray_serializers.py
@@ -24,7 +24,7 @@ from ..ndarray.serializers import (
 def test_array_from_json_correct_data():
     raw_data = memoryview(np.zeros((4, 3), dtype=np.float32))
     json_data = {
-        'buffer': raw_data,
+        'data': raw_data,
         'dtype': 'float32',
         'shape': [4, 3],
     }
@@ -44,7 +44,7 @@ def test_array_to_json_correct_data():
     json_data = array_to_json(data, None)
 
     assert json_data == {
-        'buffer': memoryview(data),
+        'data': memoryview(data),
         'dtype': str(data.dtype),
         'shape': (4, 3),
     }
@@ -77,7 +77,7 @@ def test_array_to_json_int64_warning():
 def test_union_from_json_correct_array_data():
     raw_data = memoryview(np.zeros((4, 3), dtype=np.float32))
     json_data = {
-        'buffer': raw_data,
+        'data': raw_data,
         'dtype': 'float32',
         'shape': [4, 3],
     }
@@ -102,7 +102,7 @@ def test_union_to_json_correct_array_data():
     json_data = data_union_to_json(data, None)
 
     assert json_data == {
-        'buffer': memoryview(data),
+        'data': memoryview(data),
         'dtype': str(data.dtype),
         'shape': (4, 3),
     }
@@ -121,7 +121,7 @@ def test_compressed_from_json_correct_data():
     orig_data = np.zeros((4, 3), dtype=np.float32)
     raw_data = memoryview(zlib.compress(orig_data, 6))
     json_data = {
-        'compressed_buffer': raw_data,
+        'compressed_data': raw_data,
         'dtype': 'float32',
         'shape': [4, 3],
     }
@@ -141,7 +141,7 @@ def test_compressed_to_uncompressed_json():
     json_data = array_to_compressed_json(data, None)
 
     assert json_data == {
-        'buffer': memoryview(data),
+        'data': memoryview(data),
         'dtype': str(data.dtype),
         'shape': (4, 3),
     }
@@ -157,11 +157,11 @@ def test_compressed_to_compressed_json():
     json_data = array_to_compressed_json(data, dummy)
 
     assert tuple(sorted(json_data.keys())) == (
-        'compressed_buffer', 'dtype', 'shape')
+        'compressed_data', 'dtype', 'shape')
     assert json_data['shape'] == (4, 3)
     assert json_data['dtype'] == str(data.dtype)
     # Test that decompress doesn't raise:
-    comp = json_data['compressed_buffer']
+    comp = json_data['compressed_data']
     if six.PY2:
         comp = comp.tobytes()
     zlib.decompress(comp)

--- a/packages/jupyter-datawidgets/tests/src/common.spec.ts
+++ b/packages/jupyter-datawidgets/tests/src/common.spec.ts
@@ -31,9 +31,9 @@ function createArrayModel(): NDArrayModel {
   let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
   let view = new DataView(raw_data.buffer);
   let serializedState = { array: {
-      buffer: view,
-      shape: [2, 3],
-      dtype: 'float32',
+    data: view,
+    shape: [2, 3],
+    dtype: 'float32',
   }};
   let attributes = NDArrayModel._deserialize_state(serializedState, manager);
   return createTestModel(NDArrayModel, attributes);
@@ -53,7 +53,7 @@ function createScaledModel(): Promise<NDArrayModel> {
   let view = new DataView(raw_data.buffer);
   let serializedState = {
     array: {
-      buffer: view,
+      data: view,
       shape: [2, 3],
       dtype: 'float32',
     },

--- a/packages/jupyter-datawidgets/tests/src/ndarray.spec.ts
+++ b/packages/jupyter-datawidgets/tests/src/ndarray.spec.ts
@@ -70,7 +70,7 @@ describe('NDArray', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -96,8 +96,8 @@ describe('NDArray', () => {
 
       let jsonData = arrayToJSON(array)!;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(raw_data.buffer);
       expect(jsonData.shape).to.eql([2, 3]);
       expect(jsonData.dtype).to.be('float32');
 

--- a/packages/jupyter-datawidgets/tests/src/scaled.spec.ts
+++ b/packages/jupyter-datawidgets/tests/src/scaled.spec.ts
@@ -58,7 +58,7 @@ function createWidgetModel(): ScaledArrayModel {
   let attributes = {
     scale,
     array: JSONToArray({
-      buffer: view,
+      data: view,
       shape: [2, 3],
       dtype: 'float32',
     }, widget_manager)

--- a/packages/jupyter-datawidgets/tests/src/union.spec.ts
+++ b/packages/jupyter-datawidgets/tests/src/union.spec.ts
@@ -32,9 +32,9 @@ function createWidgetModel(): NDArrayModel {
   let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
   let view = new DataView(raw_data.buffer);
   let serializedState = { array: {
-      buffer: view,
-      shape: [2, 3],
-      dtype: 'float32',
+    data: view,
+    shape: [2, 3],
+    dtype: 'float32',
   }};
   let attributes = NDArrayModel._deserialize_state(serializedState, manager);
   return createTestModel(NDArrayModel, attributes);
@@ -50,7 +50,7 @@ describe('Union Serializers', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -86,9 +86,9 @@ describe('Union Serializers', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let serializedState = { array: {
-          buffer: view,
-          shape: [2, 3],
-          dtype: 'float32',
+        data: view,
+        shape: [2, 3],
+        dtype: 'float32',
       }};
       let attributesPromise = NDArrayModel._deserialize_state(serializedState, widget_manager);
       return attributesPromise.then((attributes) => {
@@ -116,7 +116,7 @@ describe('Union Serializers', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -153,9 +153,9 @@ describe('Union Serializers', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let serializedState = { array: {
-          buffer: view,
-          shape: [2, 3],
-          dtype: 'float32',
+        data: view,
+        shape: [2, 3],
+        dtype: 'float32',
       }};
       let attributesPromise = NDArrayModel._deserialize_state(serializedState, widget_manager);
       return attributesPromise.then((attributes) => {
@@ -189,8 +189,8 @@ describe('Union Serializers', () => {
 
       let jsonData = unionToJSON(array) as ISendSerializedArray;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(raw_data.buffer);
       expect(jsonData.shape).to.eql([2, 3]);
       expect(jsonData.dtype).to.be('float32');
 

--- a/packages/serializers/tests/src/ndarray.spec.ts
+++ b/packages/serializers/tests/src/ndarray.spec.ts
@@ -34,7 +34,7 @@ describe('ndarray', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -60,8 +60,8 @@ describe('ndarray', () => {
 
       let jsonData = arrayToJSON(array)!;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(raw_data.buffer);
       expect(jsonData.shape).to.eql([2, 3]);
       expect(jsonData.dtype).to.be('float32');
 
@@ -82,7 +82,7 @@ describe('ndarray', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -102,7 +102,7 @@ describe('ndarray', () => {
       const level = 6;
       let view = new DataView(pako.deflate(raw_data.buffer as any, { level }).buffer);
       let jsonData = {
-        compressed_buffer: view,
+        compressed_data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedCompressedSerializedArray;
@@ -134,8 +134,8 @@ describe('ndarray', () => {
 
       let jsonData = arrayToCompressedJSON(model.array, model)!;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(model.raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(model.raw_data.buffer);
       expect(jsonData.shape).to.eql([2, 3]);
       expect(jsonData.dtype).to.be('float32');
 
@@ -152,11 +152,11 @@ describe('ndarray', () => {
 
       let jsonData = arrayToCompressedJSON(model.array, model) as ISendCompressedSerializedArray;
 
-      expect(jsonData.buffer).to.be(undefined);
-      expect(jsonData.compressed_buffer).to.be.a(Uint8Array);
+      expect(jsonData.data).to.be(undefined);
+      expect(jsonData.compressed_data).to.be.a(Uint8Array);
       // Not .to.be here, as run through compression loop:
-      expect(jsonData.compressed_buffer!.buffer).to.not.be(model.raw_data.buffer);
-      expect(jsonData.compressed_buffer).to.not.eql(
+      expect(jsonData.compressed_data!.buffer).to.not.be(model.raw_data.buffer);
+      expect(jsonData.compressed_data).to.not.eql(
         new Uint8Array(model.raw_data.buffer));
       expect(jsonData.shape).to.eql([2, 3]);
       expect(jsonData.dtype).to.be('float32');
@@ -175,8 +175,8 @@ describe('ndarray', () => {
 
       let jsonData = arrayToCompressedJSON(array)!;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(raw_data.buffer);
       expect(jsonData.shape).to.eql([2, 3]);
       expect(jsonData.dtype).to.be('float32');
 
@@ -193,8 +193,8 @@ describe('ndarray', () => {
 
       let jsonData = arrayToCompressedJSON(model.array, model)!;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(model.raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(model.raw_data.buffer);
       expect(jsonData.shape).to.eql([2, 3]);
       expect(jsonData.dtype).to.be('float32');
 
@@ -208,7 +208,7 @@ describe('ndarray', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -232,8 +232,8 @@ describe('ndarray', () => {
 
       let jsonData = typedArrayToJSON(raw_data)!;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(raw_data.buffer);
       expect(jsonData.shape).to.eql([6]);
       expect(jsonData.dtype).to.be('float32');
 
@@ -253,7 +253,7 @@ describe('ndarray', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -278,8 +278,8 @@ describe('ndarray', () => {
 
       let jsonData = simpleToJSON(obj)!;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(raw_data.buffer);
       expect(jsonData.shape).to.eql([2, 3]);
       expect(jsonData.dtype).to.be('float32');
 

--- a/packages/serializers/tests/src/union.spec.ts
+++ b/packages/serializers/tests/src/union.spec.ts
@@ -33,7 +33,7 @@ describe('Union Serializers', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -84,7 +84,7 @@ describe('Union Serializers', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -142,8 +142,8 @@ describe('Union Serializers', () => {
 
       let jsonData = unionToJSON(array) as ISendSerializedArray;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(raw_data.buffer);
       expect(jsonData.shape).to.eql([2, 3]);
       expect(jsonData.dtype).to.be('float32');
 
@@ -170,7 +170,7 @@ describe('Union Serializers', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -237,8 +237,8 @@ describe('Union Serializers', () => {
 
       let jsonData = unionTypedArrayToJSON(raw_data) as ISendSerializedArray;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(raw_data.buffer);
       expect(jsonData.shape).to.eql([6]);
       expect(jsonData.dtype).to.be('float32');
 
@@ -265,7 +265,7 @@ describe('Union Serializers', () => {
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
       let jsonData = {
-        buffer: view,
+        data: view,
         shape: [2, 3],
         dtype: 'float32',
       } as IReceivedSerializedArray;
@@ -333,8 +333,8 @@ describe('Union Serializers', () => {
 
       let jsonData = simpleUnionToJSON(obj) as ISendSerializedArray;
 
-      expect(jsonData.buffer).to.be.a(Float32Array);
-      expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
+      expect(jsonData.data).to.be.a(Float32Array);
+      expect((jsonData.data as Float32Array).buffer).to.be(raw_data.buffer);
       expect(jsonData.shape).to.eql([2, 3]);
       expect(jsonData.dtype).to.be('float32');
 


### PR DESCRIPTION
The `buffer` property is treated differently in ipywidgets, so renaming to go clear.

Fixes #18.