### PR TITLE
Embeddable bundle

### DIFF
--- a/packages/jupyter-datawidgets/package.json
+++ b/packages/jupyter-datawidgets/package.json
@@ -4,6 +4,14 @@
   "description": "A set of widgets to help facilitate reuse of large datasets across widgets",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",
+  "files": [
+    "lib/**/*.js",
+    "lib/**/*.js.map",
+    "lib/**/*.d.ts",
+    "dist/*.js",
+    "dist/*.js.map",
+    "dist/*.d.ts"
+  ],
   "scripts": {
     "clean:lib": "rimraf lib",
     "clean:nbextension": "rimraf ../../ipydatawidgets/nbextension/static/index.js",

--- a/packages/jupyter-datawidgets/src/scaled.ts
+++ b/packages/jupyter-datawidgets/src/scaled.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import {
-  WidgetModel, ManagerBase, unpack_models
+  WidgetModel, unpack_models
 } from '@jupyter-widgets/base';
 
 import {
@@ -15,8 +15,8 @@ import {
 
 import {
   data_union_serialization, listenToUnion,
-  TypedArray, typesToArray, IArrayLookup, TypedArrayConstructor,
-  ISerializers, getArray, ensureSerializableDtype
+  TypedArray, typesToArray, TypedArrayConstructor,
+  ISerializers, getArray
 } from 'jupyter-dataserializers';
 
 import {

--- a/packages/jupyter-datawidgets/src/version.ts
+++ b/packages/jupyter-datawidgets/src/version.ts
@@ -1,16 +1,17 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-/**
- * The version of the Jupyter data widgets attribute spec that this package
- * implements.
- */
-export
-const EXTENSION_SPEC_VERSION = '4.0.0';
-
 
 /**
  * The current package version.
  */
 export
 const version = (require('../package.json') as any).version;
+
+
+/**
+ * The semver range of this package that the serialization
+ * format is compatible with.
+ */
+export
+const EXTENSION_SPEC_VERSION = version;

--- a/packages/jupyter-datawidgets/webpack.config.js
+++ b/packages/jupyter-datawidgets/webpack.config.js
@@ -1,22 +1,61 @@
-var rules = [
+const path = require('path');
+const version = require('./package.json').version;
+
+const rules = [
   { test: /\.ts$/, loader: 'ts-loader' },
   { test: /\.js$/, loader: "source-map-loader" },
 ];
 
-module.exports = {
-  entry: './src/index.ts',
-  output: {
-    filename: 'index.js',
-    path: __dirname + '/../../ipydatawidgets/nbextension/static',
-    libraryTarget: 'amd'
+const externals = ['@jupyter-widgets/base', 'jupyter-scales'];
+
+module.exports = [
+  {
+    entry: './src/index.ts',
+    output: {
+      filename: 'index.js',
+      path: __dirname + '/../../ipydatawidgets/nbextension/static',
+      libraryTarget: 'amd'
+    },
+    module: {
+      rules: rules
+    },
+    devtool: 'source-map',
+    externals,
+    resolve: {
+      // Add '.ts' as resolvable extensions.
+      extensions: [".webpack.js", ".web.js", ".ts", ".js"]
+    }
   },
-  module: {
-    rules: rules
-  },
-  devtool: 'source-map',
-  externals: ['@jupyter-widgets/base', 'jupyter-scales'],
-  resolve: {
-    // Add '.ts' and '.tsx' as resolvable extensions.
-    extensions: [".webpack.js", ".web.js", ".ts", ".js"]
+  {// Embeddable jupyter-datawidgets bundle
+    //
+    // This bundle is generally almost identical to the notebook bundle
+    // containing the custom widget views and models.
+    //
+    // The only difference is in the configuration of the webpack public path
+    // for the static assets.
+    //
+    // It will be automatically distributed by unpkg to work with the static
+    // widget embedder.
+    //
+    // The target bundle is always `dist/index.js`, which is the path required
+    // by the custom widget embedder.
+    //
+    entry: './src/index.ts',
+    output: {
+        filename: 'index.js',
+        path: path.resolve(__dirname, 'dist'),
+        libraryTarget: 'amd',
+        library: "jupyter-datawidgets",
+        publicPath: 'https://unpkg.com/jupyter-datawidgets@' + version + '/dist/'
+    },
+    devtool: 'source-map',
+    module: {
+        rules: rules
+    },
+    externals,
+    resolve: {
+      // Add '.ts' as resolvable extensions.
+      extensions: [".webpack.js", ".web.js", ".ts", ".js"]
+    },
   }
-};
+];


### PR DESCRIPTION
Adds a bundle compilation to `/dist/index.js`, so that the module can be loaded by the html managers of jupyter widgets. `jupyter-scales` will also need a similar bundle.