### PR TITLE
Make ipyscales an optional dependency

### DIFF
--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -557,7 +557,8 @@
    "metadata": {
     "scrolled": false,
     "tags": [
-     "raises-exception"
+     "raises-exception",
+     "nbval-ignore-output"
     ]
    },
    "outputs": [

--- a/ipydatawidgets/__init__.py
+++ b/ipydatawidgets/__init__.py
@@ -6,7 +6,6 @@
 
 from .ndarray import *
 from .widgets import DataWidget
-from .scaled import ScaledArrayWidget
 from ._version import __version__, version_info
 
 from .nbextension import _jupyter_nbextension_paths

--- a/packages/jlabextension/package.json
+++ b/packages/jlabextension/package.json
@@ -6,8 +6,7 @@
   "typings": "build/index.d.ts",
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.8",
-    "jupyter-datawidgets": "^4.0.1",
-    "jupyterlab-scales": "^0.2.0"
+    "jupyter-datawidgets": "^4.0.1"
   },
   "devDependencies": {
     "@phosphor/application": "^1.5.0",

--- a/packages/jupyter-datawidgets/package.json
+++ b/packages/jupyter-datawidgets/package.json
@@ -38,6 +38,7 @@
     "@types/ndarray": "^1.0.5",
     "@types/node": "^9.4.6",
     "expect.js": "^0.3.1",
+    "jupyter-scales": "^1.1.0",
     "karma": "^2.0.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-firefox-launcher": "^1.1.0",
@@ -55,7 +56,6 @@
   "dependencies": {
     "@jupyter-widgets/base": "^1.1.8",
     "jupyter-dataserializers": "^1.1.2",
-    "jupyter-scales": "^1.1.0",
     "ndarray": "^1.0.18"
   }
 }

--- a/packages/jupyter-datawidgets/webpack.config.js
+++ b/packages/jupyter-datawidgets/webpack.config.js
@@ -6,7 +6,7 @@ const rules = [
   { test: /\.js$/, loader: "source-map-loader" },
 ];
 
-const externals = ['@jupyter-widgets/base', 'jupyter-scales'];
+const externals = ['@jupyter-widgets/base'];
 
 module.exports = [
   {

--- a/packages/serializers/tests/src/common.spec.ts
+++ b/packages/serializers/tests/src/common.spec.ts
@@ -1,10 +1,6 @@
 
 import {
-  LinearScaleModel
-} from 'jupyter-scales';
-
-import {
-  DataUnion, getArray, IDataSource
+  getArray, IDataSource
 } from '../../src';
 
 import ndarray = require('ndarray');

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,6 @@ setup_args = dict(
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'ipywidgets>=7.0.0',
-    'ipyscales>=0.1.1',
     'numpy',
     'six',
     'traittypes>=0.2.0',


### PR DESCRIPTION
- Only requires ipyscales if you import `ipydatawidgets.scaled`.
- Makes JS dependency a dev dependency only (for typings).
- Fix an nbval test