### PR TITLE
Add fixed shape serializer on JS side

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,18 +5,20 @@ skip_branch_with_pr: true
 environment:
   nodejs_version: "8"
   matrix:
-    - PYTHON: "C:\\Miniconda36-x64"
-      PYTHON_VERSION: "3.6.x"
+    - PYTHON: "C:\\Miniconda3-x64"
+      PYTHON_VERSION: "3.7"
       PYTHON_MAJOR: 3
       PYTHON_ARCH: "64"
     - PYTHON: "C:\\Miniconda3"
-      PYTHON_VERSION: "3.4.x"
+      PYTHON_VERSION: "3.4"
       PYTHON_MAJOR: 3
       PYTHON_ARCH: "32"
 
 # build cache to preserve files/folders between builds
 cache:
   - '%AppData%/npm-cache'
+  - '%PYTHON%/pkgs'
+  - '%LOCALAPPDATA%\pip\Cache'
 
 # scripts that run after cloning repository
 install:
@@ -24,9 +26,14 @@ install:
   - ps: Install-Product node $env:nodejs_version
   # Ensure python scripts are from right version:
   - 'SET "PATH=%PYTHON%\Scripts;%PYTHON%;%PATH%"'
-  # Update install tools:
+  # Setup conda:
   - 'conda list'
   - 'conda update conda -y'
+  # If 32 bit, force conda to use it:
+  - 'IF %PYTHON_ARCH% EQU 32 SET CONDA_FORCE_32BIT=1'
+  - 'conda create -n test_env python=%PYTHON_VERSION% -y'
+  - 'activate test_env'
+  # Update install tools:
   - 'conda install setuptools pip -y'
   - 'python -m pip install --upgrade pip'
   - 'python -m easy_install --upgrade setuptools'

--- a/packages/serializers/src/util.ts
+++ b/packages/serializers/src/util.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+export function arraysEqual<T>(a: T[] | null | undefined, b: T[] | null | undefined) {
+  if (a === b) return true;
+  if (a == null || b == null) return false;
+  if (a.length !== b.length) return false;
+
+  for (let i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}

--- a/packages/serializers/tests/src/union.spec.ts
+++ b/packages/serializers/tests/src/union.spec.ts
@@ -6,10 +6,6 @@ import expect = require('expect.js');
 import ndarray = require('ndarray');
 
 import {
-  uuid, WidgetModel
-} from '@jupyter-widgets/base';
-
-import {
   JSONToUnion, JSONToUnionArray, unionToJSON, IReceivedSerializedArray,
   ISendSerializedArray, listenToUnion, JSONToUnionTypedArray,
   unionTypedArrayToJSON, JSONToSimpleUnion, simpleUnionToJSON
@@ -21,7 +17,7 @@ import {
 
 import {
   createTestModel, TestModel, NullTestModel
-} from './util.spec';
+} from './util';
 
 
 describe('Union Serializers', () => {

--- a/packages/serializers/tests/src/util.spec.ts
+++ b/packages/serializers/tests/src/util.spec.ts
@@ -1,70 +1,40 @@
-// Copyright (c) Jupyter Development Team.
-// Distributed under the terms of the Modified BSD License.
-
 import {
-  uuid, WidgetModel
-} from '@jupyter-widgets/base';
-
-import {
-  DummyManager
-} from './dummy-manager.spec';
-
-import {
-  IDataSource
-} from '../../src';
-
-import ndarray = require('ndarray');
+  arraysEqual
+} from '../../src/util';
 
 
-export
-interface ModelConstructor<T> {
-    new (attributes?: any, options?: any): T;
-}
+describe('arraysEqual', () => {
 
+  it('should equal for two nulls', () => {
+    expect(arraysEqual(null, null)).to.be(true);
+  });
 
-export
-class NullTestModel extends WidgetModel implements IDataSource {
-  getNDArray(key?: string): ndarray | null {
-    return null;
-  }
-}
+  it('should equal for two undefined', () => {
+    expect(arraysEqual(undefined, undefined)).to.be(true);
+  });
 
+  it('should equal for two small arrays', () => {
+    expect(arraysEqual([1, 2, 3], [1, 2, 3])).to.be(true);
+  });
 
-export
-class TestModel extends WidgetModel implements IDataSource {
-  initialize(attributes: any, options: any) {
-    super.initialize(attributes, options);
-    this.raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
-    this.array = ndarray(this.raw_data, [2, 3]);
-  }
+  it('should equal when passing same instance', () => {
+    const a = [1, 2, 3];
+    expect(arraysEqual(a, a)).to.be(true);
+  });
 
-  defaults() {
-    return {
-      ...super.defaults(),
-      compression_level: 0,
-    }
-  }
+  it('should not equal for two different arrays of same length', () => {
+    expect(arraysEqual([1, 4, 6], [1, 2, 3])).to.be(false);
+    expect(arraysEqual([1, 2, 3], [1, 4, 6])).to.be(false);
+  });
 
-  getNDArray(key?: string): ndarray | null {
-    return this.array;
-  }
+  it('should not equal for two similar arrays of different length', () => {
+    expect(arraysEqual([1, 2, 3], [1, 2, 3, 4, 5])).to.be(false);
+    expect(arraysEqual([1, 2, 3, 4, 5], [1, 2, 3])).to.be(false);
+  });
 
-  raw_data: Float32Array;
-  array: ndarray;
-}
+  it('should not equal for null and undefined', () => {
+    expect(arraysEqual(null, undefined)).to.be(false);
+    expect(arraysEqual(undefined, null)).to.be(false);
+  });
 
-
-export
-function createTestModel<T extends WidgetModel>(
-    constructor: ModelConstructor<T>,
-    attributes?: any,
-    widget_manager?: DummyManager,
-    ): T {
-  let id = uuid();
-  let modelOptions = {
-      widget_manager: widget_manager || new DummyManager(),
-      model_id: id,
-  }
-
-  return new constructor(attributes, modelOptions);
-}
+});

--- a/packages/serializers/tests/src/util.ts
+++ b/packages/serializers/tests/src/util.ts
@@ -1,0 +1,70 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  uuid, WidgetModel
+} from '@jupyter-widgets/base';
+
+import {
+  DummyManager
+} from './dummy-manager.spec';
+
+import {
+  IDataSource
+} from '../../src';
+
+import ndarray = require('ndarray');
+
+
+export
+interface ModelConstructor<T> {
+    new (attributes?: any, options?: any): T;
+}
+
+
+export
+class NullTestModel extends WidgetModel implements IDataSource {
+  getNDArray(key?: string): ndarray | null {
+    return null;
+  }
+}
+
+
+export
+class TestModel extends WidgetModel implements IDataSource {
+  initialize(attributes: any, options: any) {
+    super.initialize(attributes, options);
+    this.raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
+    this.array = ndarray(this.raw_data, [2, 3]);
+  }
+
+  defaults() {
+    return {
+      ...super.defaults(),
+      compression_level: 0,
+    }
+  }
+
+  getNDArray(key?: string): ndarray | null {
+    return this.array;
+  }
+
+  raw_data: Float32Array;
+  array: ndarray;
+}
+
+
+export
+function createTestModel<T extends WidgetModel>(
+    constructor: ModelConstructor<T>,
+    attributes?: any,
+    widget_manager?: DummyManager,
+    ): T {
+  let id = uuid();
+  let modelOptions = {
+      widget_manager: widget_manager || new DummyManager(),
+      model_id: id,
+  }
+
+  return new constructor(attributes, modelOptions);
+}


### PR DESCRIPTION
Simplest to use serializer while still retaining shape information on sync round-trip.

CC @thewtex