### PR TITLE
Lazy load pako

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,7 +144,7 @@ $RECYCLE.BIN/
 # ----
 
 **/node_modules/
-ipydatawidgets/nbextension/static/index.*
+ipydatawidgets/nbextension/static/*index.*
 
 # Coverage data
 # -------------

--- a/packages/jupyter-datawidgets/src/extension.ts
+++ b/packages/jupyter-datawidgets/src/extension.ts
@@ -1,0 +1,10 @@
+// Entry point for the notebook bundle containing custom model definitions.
+//
+// Setup notebook base URL
+//
+// Some static assets may be required by the custom widget javascript. The base
+// url for the notebook is not known at build time and is therefore computed
+// dynamically.
+__webpack_public_path__ = document.querySelector('body')!.getAttribute('data-base-url') + 'nbextensions/jupyter-datawidgets/';
+
+export * from './index';

--- a/packages/jupyter-datawidgets/tests/karma.conf.js
+++ b/packages/jupyter-datawidgets/tests/karma.conf.js
@@ -11,7 +11,10 @@ module.exports = function (config) {
     },
     files: [
       { pattern: "tests/src/**/*.ts" },
-      { pattern: "src/**/*.ts" }
+      { pattern: "src/**/*.ts" },
+    ],
+    exclude: [
+      "src/extension.ts",
     ],
     preprocessors: {
       '**/*.ts': ['karma-typescript']

--- a/packages/jupyter-datawidgets/webpack.config.js
+++ b/packages/jupyter-datawidgets/webpack.config.js
@@ -1,6 +1,9 @@
 const path = require('path');
 const version = require('./package.json').version;
 
+const extStaticPath = path.resolve(
+  __dirname, '..', '..', 'ipydatawidgets', 'nbextension', 'static');
+
 const rules = [
   { test: /\.ts$/, loader: 'ts-loader' },
   { test: /\.js$/, loader: "source-map-loader" },
@@ -8,12 +11,17 @@ const rules = [
 
 const externals = ['@jupyter-widgets/base'];
 
+const resolve = {
+  // Add '.ts' as resolvable extensions.
+  extensions: [".webpack.js", ".web.js", ".ts", ".js"]
+}
+
 module.exports = [
   {
     entry: './src/index.ts',
     output: {
       filename: 'index.js',
-      path: __dirname + '/../../ipydatawidgets/nbextension/static',
+      path: extStaticPath,
       libraryTarget: 'amd'
     },
     module: {
@@ -21,10 +29,7 @@ module.exports = [
     },
     devtool: 'source-map',
     externals,
-    resolve: {
-      // Add '.ts' as resolvable extensions.
-      extensions: [".webpack.js", ".web.js", ".ts", ".js"]
-    }
+    resolve,
   },
   {// Embeddable jupyter-datawidgets bundle
     //
@@ -53,9 +58,6 @@ module.exports = [
         rules: rules
     },
     externals,
-    resolve: {
-      // Add '.ts' as resolvable extensions.
-      extensions: [".webpack.js", ".web.js", ".ts", ".js"]
-    },
+    resolve,
   }
 ];

--- a/packages/jupyter-datawidgets/webpack.config.js
+++ b/packages/jupyter-datawidgets/webpack.config.js
@@ -18,7 +18,8 @@ const resolve = {
 
 module.exports = [
   {
-    entry: './src/index.ts',
+    // Notebook extension
+    entry: './src/extension.ts',
     output: {
       filename: 'index.js',
       path: extStaticPath,

--- a/packages/serializers/package.json
+++ b/packages/serializers/package.json
@@ -26,6 +26,7 @@
     "@types/ndarray": "^1.0.5",
     "@types/node": "^9.4.6",
     "@types/pako": "^1.0.0",
+    "@types/webpack-env": "^1.13.6",
     "expect.js": "^0.3.1",
     "karma": "^2.0.0",
     "karma-chrome-launcher": "^2.2.0",

--- a/packages/serializers/src/compression.ts
+++ b/packages/serializers/src/compression.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+// Only used for typing, will be removed in transpile step
+import * as PakoModuleType from 'pako';
+
+let pakoReady: Promise<typeof PakoModuleType>;
+let _pako: typeof PakoModuleType;
+
+function ensurePako(): Promise<typeof PakoModuleType> {
+  if (pakoReady) {
+    return pakoReady;
+  }
+
+  pakoReady = new Promise((resolve, reject) => {
+    require.ensure(
+      ['pako'],
+      // see https://webpack.js.org/api/module-methods/#require-ensure
+      // this argument MUST be named `require` for the WebPack parser
+      require => {
+        _pako = require('pako') as typeof PakoModuleType;
+        resolve(_pako);
+      },
+      (error: any) => {
+        console.error(error);
+        reject();
+      },
+      'pako'
+    );
+  });
+
+  return pakoReady;
+}
+
+/**
+ * Compress the buffer using zlib compression.
+ */
+export async function compress(buffer: ArrayBuffer, level: number): Promise<Uint8Array> {
+    const pako = await ensurePako();
+    return pako.deflate(new Uint8Array(buffer), {level});
+}
+
+/**
+ * Decompress a zlib compressed buffer.
+ */
+export async function decompress(buffer: ArrayBuffer): Promise<ArrayBuffer> {
+    const pako = await ensurePako();
+    return pako.inflate(new Uint8Array(buffer)).buffer;
+}

--- a/packages/serializers/src/compression.ts
+++ b/packages/serializers/src/compression.ts
@@ -4,15 +4,18 @@
 // Only used for typing, will be removed in transpile step
 import * as PakoModuleType from 'pako';
 
-let pakoReady: Promise<typeof PakoModuleType>;
+// Polyfill webpack require.ensure.
+if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require);    
+
+let _pakoReady: Promise<typeof PakoModuleType>;
 let _pako: typeof PakoModuleType;
 
 function ensurePako(): Promise<typeof PakoModuleType> {
-  if (pakoReady) {
-    return pakoReady;
+  if (_pakoReady) {
+    return _pakoReady;
   }
 
-  pakoReady = new Promise((resolve, reject) => {
+  _pakoReady = new Promise((resolve, reject) => {
     require.ensure(
       ['pako'],
       // see https://webpack.js.org/api/module-methods/#require-ensure
@@ -29,7 +32,7 @@ function ensurePako(): Promise<typeof PakoModuleType> {
     );
   });
 
-  return pakoReady;
+  return _pakoReady;
 }
 
 /**

--- a/packages/serializers/src/ndarray.ts
+++ b/packages/serializers/src/ndarray.ts
@@ -11,8 +11,6 @@ import {
 
 import ndarray = require('ndarray');
 
-import pako = require("pako");
-
 
 export
 type TypedArray = Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array;
@@ -146,6 +144,8 @@ const typesToArray = {
 
 export
 function compressedJSONToArray(obj: IReceivedCompressedSerializedArray | null, manager?: ManagerBase<any>): ndarray | null {
+  const pako = require("pako");
+
   if (obj === null) {
     return null;
   }
@@ -162,6 +162,8 @@ function compressedJSONToArray(obj: IReceivedCompressedSerializedArray | null, m
 
 export
 function arrayToCompressedJSON(obj: ndarray | null, widget?: WidgetModel): SendSerializedArray | null {
+  const pako = require("pako");
+
   if (obj === null) {
     return null;
   }

--- a/packages/serializers/src/ndarray.ts
+++ b/packages/serializers/src/ndarray.ts
@@ -9,6 +9,10 @@ import {
   arraysEqual
 } from './util';
 
+import {
+  compress, decompress
+} from './compression';
+
 import ndarray = require('ndarray');
 
 
@@ -142,16 +146,16 @@ const typesToArray = {
 }
 
 
-export
-function compressedJSONToArray(obj: IReceivedCompressedSerializedArray | null, manager?: ManagerBase<any>): ndarray | null {
-  const pako = require("pako");
-
+export async function compressedJSONToArray(
+  obj: IReceivedCompressedSerializedArray | null,
+  manager?: ManagerBase<any>
+): Promise<ndarray | null> {
   if (obj === null) {
     return null;
   }
-  let buffer;
+  let buffer: ArrayBuffer;
   if (obj.compressed_buffer !== undefined) {
-    buffer = pako.inflate(new Uint8Array(obj.compressed_buffer.buffer)).buffer;
+    buffer = await decompress(obj.compressed_buffer.buffer);
   } else {
     buffer = obj.buffer!.buffer;
   }
@@ -160,19 +164,19 @@ function compressedJSONToArray(obj: IReceivedCompressedSerializedArray | null, m
   return ndarray(new typesToArray[obj.dtype](buffer), obj.shape);
 }
 
-export
-function arrayToCompressedJSON(obj: ndarray | null, widget?: WidgetModel): SendSerializedArray | null {
-  const pako = require("pako");
-
+export async function arrayToCompressedJSON(
+  obj: ndarray | null,
+  widget?: WidgetModel
+): Promise<SendSerializedArray | null> {
   if (obj === null) {
     return null;
   }
   let dtype = ensureSerializableDtype(obj.dtype);
-  const level = widget ? widget.get('compression_level') : 0;
+  const level = widget ? widget.get('compression_level') as number | undefined : 0;
   if (level !== undefined && level > 0) {
-    const compressed_buffer = pako.deflate(
-      new Uint8Array((obj.data as TypedArray).buffer),
-      { level }
+    const compressed_buffer = await compress(
+      (obj.data as TypedArray).buffer,
+      level
     );
     // serialize to {shape: list, dtype: string, array: buffer}
     return { shape: obj.shape, dtype, compressed_buffer };

--- a/packages/serializers/src/tsconfig.json
+++ b/packages/serializers/src/tsconfig.json
@@ -8,7 +8,6 @@
       "module": "commonjs",
       "moduleResolution": "node",
       "target": "ES5",
-      "types": ["webpack-env"],
       "outDir": "../lib",
       "skipLibCheck": true,
       "sourceMap": true

--- a/packages/serializers/src/tsconfig.json
+++ b/packages/serializers/src/tsconfig.json
@@ -8,6 +8,7 @@
       "module": "commonjs",
       "moduleResolution": "node",
       "target": "ES5",
+      "types": ["webpack-env"],
       "outDir": "../lib",
       "skipLibCheck": true,
       "sourceMap": true

--- a/packages/serializers/tests/src/ndarray.spec.ts
+++ b/packages/serializers/tests/src/ndarray.spec.ts
@@ -25,6 +25,11 @@ import ndarray = require('ndarray');
 import pako = require("pako");
 
 
+if (!require.ensure) {
+  require.ensure = (deps, cb) => cb(require);
+}
+
+
 describe('ndarray', () => {
 
   describe('standard serializers', () => {
@@ -77,7 +82,7 @@ describe('ndarray', () => {
 
   describe('compressed serializers', () => {
 
-    it('should deserialize a non-compressed array', () => {
+    it('should deserialize a non-compressed array', async () => {
 
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let view = new DataView(raw_data.buffer);
@@ -87,7 +92,7 @@ describe('ndarray', () => {
         dtype: 'float32',
       } as IReceivedSerializedArray;
 
-      let array = compressedJSONToArray(jsonData)!;
+      let array = (await compressedJSONToArray(jsonData))!;
 
       expect(array.data).to.be.a(Float32Array);
       expect((array.data as Float32Array).buffer).to.be(raw_data.buffer);
@@ -96,7 +101,7 @@ describe('ndarray', () => {
 
     });
 
-    it('should deserialize a compressed array', () => {
+    it('should deserialize a compressed array', async () => {
 
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       const level = 6;
@@ -107,7 +112,7 @@ describe('ndarray', () => {
         dtype: 'float32',
       } as IReceivedCompressedSerializedArray;
 
-      let array = compressedJSONToArray(jsonData)!;
+      let array = (await compressedJSONToArray(jsonData))!;
 
       expect(array.data).to.be.a(Float32Array);
       // Not .to.be here, as run through compression loop:
@@ -118,12 +123,12 @@ describe('ndarray', () => {
 
     });
 
-    it('should deserialize null to null', () => {
-      let output = compressedJSONToArray(null);
+    it('should deserialize null to null', async () => {
+      let output = await compressedJSONToArray(null);
       expect(output).to.be(null);
     });
 
-    it('should serialize an uncompressed ndarray', () => {
+    it('should serialize an uncompressed ndarray', async () => {
 
       // First set up a test NDArrayModel
       let widget_manager = new DummyManager();
@@ -132,7 +137,7 @@ describe('ndarray', () => {
       (widget_manager as any)._models[model.model_id] = Promise.resolve(model);
       model.set('compression_level', 0);
 
-      let jsonData = arrayToCompressedJSON(model.array, model)!;
+      let jsonData = (await arrayToCompressedJSON(model.array, model))!;
 
       expect(jsonData.buffer).to.be.a(Float32Array);
       expect((jsonData.buffer as Float32Array).buffer).to.be(model.raw_data.buffer);
@@ -141,7 +146,7 @@ describe('ndarray', () => {
 
     });
 
-    it('should serialize a compressed ndarray', () => {
+    it('should serialize a compressed ndarray', async () => {
 
       // First set up a test NDArrayModel
       let widget_manager = new DummyManager();
@@ -150,7 +155,7 @@ describe('ndarray', () => {
       (widget_manager as any)._models[model.model_id] = Promise.resolve(model);
       model.set('compression_level', 6);
 
-      let jsonData = arrayToCompressedJSON(model.array, model) as ISendCompressedSerializedArray;
+      let jsonData = (await arrayToCompressedJSON(model.array, model)) as ISendCompressedSerializedArray;
 
       expect(jsonData.buffer).to.be(undefined);
       expect(jsonData.compressed_buffer).to.be.a(Uint8Array);
@@ -163,17 +168,17 @@ describe('ndarray', () => {
 
     });
 
-    it('should serialize null to null', () => {
-      let output = arrayToCompressedJSON(null);
+    it('should serialize null to null', async () => {
+      let output = await arrayToCompressedJSON(null);
       expect(output).to.be(null);
     });
 
-    it('should not compress when model not given', () => {
+    it('should not compress when model not given', async () => {
 
       let raw_data = new Float32Array([1, 2, 3, 4, 5, 10]);
       let array = ndarray(raw_data, [2, 3]);
 
-      let jsonData = arrayToCompressedJSON(array)!;
+      let jsonData = (await arrayToCompressedJSON(array))!;
 
       expect(jsonData.buffer).to.be.a(Float32Array);
       expect((jsonData.buffer as Float32Array).buffer).to.be(raw_data.buffer);
@@ -182,7 +187,7 @@ describe('ndarray', () => {
 
     });
 
-    it('should not compress a model without compression_level', () => {
+    it('should not compress a model without compression_level', async () => {
 
       // First set up a test NDArrayModel
       let widget_manager = new DummyManager();
@@ -191,7 +196,7 @@ describe('ndarray', () => {
       (widget_manager as any)._models[model.model_id] = Promise.resolve(model);
       model.unset('compression_level');
 
-      let jsonData = arrayToCompressedJSON(model.array, model)!;
+      let jsonData = (await arrayToCompressedJSON(model.array, model))!;
 
       expect(jsonData.buffer).to.be.a(Float32Array);
       expect((jsonData.buffer as Float32Array).buffer).to.be(model.raw_data.buffer);


### PR DESCRIPTION
This might make it easier for dependents to optimize behavior (don't load pako until compression is actually used).

TODO:
- [x] Have nbextension bundle chunk pako + dependencies separately.