### PR TITLE
Revert lazy pako

### DIFF
--- a/packages/serializers/src/compression.ts
+++ b/packages/serializers/src/compression.ts
@@ -1,52 +1,18 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-// Only used for typing, will be removed in transpile step
-import * as PakoModuleType from 'pako';
-
-// Polyfill webpack require.ensure.
-if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require);    
-
-let _pakoReady: Promise<typeof PakoModuleType>;
-let _pako: typeof PakoModuleType;
-
-function ensurePako(): Promise<typeof PakoModuleType> {
-  if (_pakoReady) {
-    return _pakoReady;
-  }
-
-  _pakoReady = new Promise((resolve, reject) => {
-    require.ensure(
-      ['pako'],
-      // see https://webpack.js.org/api/module-methods/#require-ensure
-      // this argument MUST be named `require` for the WebPack parser
-      require => {
-        _pako = require('pako') as typeof PakoModuleType;
-        resolve(_pako);
-      },
-      (error: any) => {
-        console.error(error);
-        reject();
-      },
-      'pako'
-    );
-  });
-
-  return _pakoReady;
-}
+import pako = require('pako');
 
 /**
  * Compress the buffer using zlib compression.
  */
-export async function compress(buffer: ArrayBuffer, level: number): Promise<Uint8Array> {
-    const pako = await ensurePako();
+export function compress(buffer: ArrayBuffer, level: number): Uint8Array {
     return pako.deflate(new Uint8Array(buffer), {level});
 }
 
 /**
  * Decompress a zlib compressed buffer.
  */
-export async function decompress(buffer: ArrayBuffer): Promise<ArrayBuffer> {
-    const pako = await ensurePako();
+export function decompress(buffer: ArrayBuffer): ArrayBuffer {
     return pako.inflate(new Uint8Array(buffer)).buffer;
 }

--- a/packages/serializers/tests/src/ndarray.spec.ts
+++ b/packages/serializers/tests/src/ndarray.spec.ts
@@ -25,11 +25,6 @@ import ndarray = require('ndarray');
 import pako = require("pako");
 
 
-if (!require.ensure) {
-  require.ensure = (deps, cb) => cb(require);
-}
-
-
 describe('ndarray', () => {
 
   describe('standard serializers', () => {


### PR DESCRIPTION
Keep the build tools config fixes, but revert lazy loading of pako. It just adds complexity for dependents, with little gain (the minified pako part isn't very large, ~30kB).